### PR TITLE
fix: backup export 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("dagger.hilt.android.plugin")
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 ktlint {
@@ -20,8 +21,8 @@ android {
         applicationId = "com.opennotes"
         minSdk = 26
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.3.9"
+        versionCode = 14
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -108,7 +109,7 @@ dependencies {
     ksp(libs.room.compiler)
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.android)
-    implementation(libs.gson)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.core.splashscreen)
     implementation(libs.biometric)
     implementation(libs.glance.appwidget)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,8 +7,3 @@
 -keepnames class com.google.gson.Gson
 -keepnames class com.google.gson.JsonDeserializer
 -keepnames class com.google.gson.JsonSerializer
-
--keep class com.opennotes.featureNode.domain.model.** { *; }
-
--keep class com.opennotes.featureNode.data.repository.GsonJsonHandler { *; }
--keep interface com.opennotes.featureNode.data.repository.JsonHandler { *; }

--- a/app/src/main/java/com/opennotes/di/AppModule.kt
+++ b/app/src/main/java/com/opennotes/di/AppModule.kt
@@ -23,8 +23,8 @@ import androidx.room.Room
 import com.opennotes.notes.data.datasource.NoteDatabase
 import com.opennotes.notes.data.repository.AndroidFileHandler
 import com.opennotes.notes.data.repository.FileHandler
-import com.opennotes.notes.data.repository.GsonJsonHandler
 import com.opennotes.notes.data.repository.JsonHandler
+import com.opennotes.notes.data.repository.KotlinxJsonHandler
 import com.opennotes.notes.data.repository.NoteRepositoryImpl
 import com.opennotes.notes.domain.repository.NoteRepository
 import com.opennotes.notes.domain.usecase.AddNote
@@ -64,10 +64,10 @@ object AppModule {
     @Singleton
     fun provideFileHandler(app: Application): FileHandler = AndroidFileHandler(app)
 
-    // CORRECTED: Provides the concrete GsonJsonHandler implementation
+    // CORRECTED: Provides the concrete KotlinxJsonHandler implementation
     @Provides
     @Singleton
-    fun provideJsonHandler(): JsonHandler = GsonJsonHandler()
+    fun provideJsonHandler(): JsonHandler = KotlinxJsonHandler()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/opennotes/notes/data/repository/JsonHandler.kt
+++ b/app/src/main/java/com/opennotes/notes/data/repository/JsonHandler.kt
@@ -18,23 +18,25 @@
 
 package com.opennotes.notes.data.repository
 
-import com.google.gson.GsonBuilder
-
-// In your data/repository directory
+import com.opennotes.notes.domain.model.Note
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.*
 
 interface JsonHandler {
-    fun <T> toJson(data: T): String
+    fun serializeNotes(notes: List<Note>): String
 
-    fun fromJsonToNoteMapList(json: String): List<Map<String, Any?>>
+    fun parseToJsonArray(json: String): JsonArray
 }
 
-class GsonJsonHandler : JsonHandler {
-    private val gson = GsonBuilder().create()
+class KotlinxJsonHandler : JsonHandler {
+    private val jsonFormat =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+            isLenient = true
+        }
 
-    override fun <T> toJson(data: T): String = gson.toJson(data)
+    override fun serializeNotes(notes: List<Note>): String = jsonFormat.encodeToString(notes)
 
-    override fun fromJsonToNoteMapList(json: String): List<Map<String, Any?>> {
-        val noteListType = object : com.google.gson.reflect.TypeToken<List<Map<String, Any?>>>() {}.type
-        return gson.fromJson(json, noteListType)
-    }
+    override fun parseToJsonArray(json: String): JsonArray = jsonFormat.parseToJsonElement(json).jsonArray
 }

--- a/app/src/main/java/com/opennotes/notes/domain/model/Note.kt
+++ b/app/src/main/java/com/opennotes/notes/domain/model/Note.kt
@@ -18,6 +18,9 @@
 
 package com.opennotes.notes.domain.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Note(
     val title: String,
     val content: String,

--- a/app/src/main/java/com/opennotes/notes/domain/usecase/ExportUseCases.kt
+++ b/app/src/main/java/com/opennotes/notes/domain/usecase/ExportUseCases.kt
@@ -40,7 +40,7 @@ class ExportUseCases(
                 return ExportResult.Error("No notes to export")
             }
 
-            val notesJson = jsonHandler.toJson(allNotes)
+            val notesJson = jsonHandler.serializeNotes(allNotes)
 
             val isSaved = fileHandler.exportBackupToZip(targetUriString, notesJson)
 

--- a/app/src/main/java/com/opennotes/notes/domain/usecase/ImportUseCases.kt
+++ b/app/src/main/java/com/opennotes/notes/domain/usecase/ImportUseCases.kt
@@ -23,6 +23,7 @@ import com.opennotes.notes.data.repository.JsonHandler
 import com.opennotes.notes.domain.model.Note
 import com.opennotes.notes.domain.repository.NoteRepository
 import com.opennotes.notes.domain.util.ImportResult
+import kotlinx.serialization.json.*
 
 class ImportUseCases(
     private val repository: NoteRepository,
@@ -43,9 +44,9 @@ class ImportUseCases(
             }
 
             // Deserialize with validation - catch invalid JSON first
-            val rawNotes: List<Map<String, Any?>> =
+            val rawNotes =
                 try {
-                    jsonHandler.fromJsonToNoteMapList(notesJson)
+                    jsonHandler.parseToJsonArray(notesJson)
                 } catch (e: Exception) {
                     return ImportResult.Error("Invalid JSON format: ${e.message}")
                 }
@@ -56,11 +57,12 @@ class ImportUseCases(
 
             // Validate and construct trusted Note objects
             val validNotes =
-                rawNotes.mapNotNull { rawNote ->
-                    val title = (rawNote["title"] as? String)?.trim()
-                    val content = (rawNote["content"] as? String)?.trim()
-                    val timestamp = (rawNote["timestamp"] as? Number)?.toLong()
-                    val color = (rawNote["color"] as? Number)?.toInt()
+                rawNotes.mapNotNull { element ->
+                    val rawNote = element as? JsonObject ?: return@mapNotNull null
+                    val title = rawNote["title"]?.jsonPrimitive?.contentOrNull?.trim()
+                    val content = rawNote["content"]?.jsonPrimitive?.contentOrNull?.trim()
+                    val timestamp = rawNote["timestamp"]?.jsonPrimitive?.longOrNull
+                    val color = rawNote["color"]?.jsonPrimitive?.intOrNull
 
                     // Only create Note if all required fields are present and valid
                     if ((title?.isNotBlank() == true || content?.isNotBlank() == true) &&

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ ktlint = "14.2.0"
 material3 = "1.4.0-alpha02"
 coil = "2.6.0"
 work = "2.9.0"
+kotlinx-serialization-json = "1.7.3"
 
 [libraries]
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
@@ -63,6 +64,7 @@ espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "esp
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 
 [plugins]
 android-application = { id = "com.android.application", version = "8.9.1" }
@@ -71,3 +73,4 @@ ksp = { id = "com.google.devtools.ksp", version = "2.1.0-1.0.29" }
 compose = { id = "org.jetbrains.kotlin.plugin.compose", version = "2.1.0" }
 hilt = { id = "com.google.dagger.hilt.android", version = "2.51.1" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.1.0" }


### PR DESCRIPTION
backup export broken in v1.3.9
This pr fixes it by migrating to kotlinx.seralization and not relying on proguard-rules.pro


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kotlin serialization support for exporting and importing notes.
  * Notes can now be serialized more reliably with built-in JSON handling.
* **Bug Fixes**
  * Improved JSON parsing during imports to better handle missing or malformed values.
  * Updated app versioning to a new release number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->